### PR TITLE
Add support for custom TTF fonts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target/
 Cargo.lock
+.idea/

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,16 +19,18 @@ use misc::{AppInfo, ArgState};
 use shh::{ShhStderr, ShhStdout};
 
 pub use clap;
+pub use misc::FontConfig;
 
 /// Run a clap [`Command`] as a GUI
 pub fn run<F: Fn(&ArgMatches) + Send + Sync + 'static>(
     app: Command,
     func: F,
+    font_config: Option<FontConfig>
 ) -> Result<(), eframe::Error> {
     eframe::run_native(
         app.clone().get_name(),
         eframe::NativeOptions::default(),
-        Box::new(|_cc| Box::new(Claui::new(app, Arc::new(func)))),
+        Box::new(|_cc| Box::new(Claui::new(app, Arc::new(func),font_config))),
     )
 }
 
@@ -46,10 +48,12 @@ struct Claui {
     func_handle: Option<Arc<JoinHandle<()>>>,
     args: Vec<ArgState>,
     ui_arg_state: HashMap<String, (bool, String)>,
+    font_config: Option<FontConfig>,
+    font_loaded: bool,
 }
 
 impl Claui {
-    pub fn new(app: Command, func: SharedFunction) -> Self {
+    pub fn new(app: Command, func: SharedFunction,font_config: Option<FontConfig>) -> Self {
         let app = Box::new(app);
         let app_info = AppInfo::new(&app);
 
@@ -76,6 +80,8 @@ impl Claui {
             func_handle: None,
             args,
             ui_arg_state,
+            font_config,
+            font_loaded: false,
         }
     }
 

--- a/src/misc.rs
+++ b/src/misc.rs
@@ -52,6 +52,11 @@ impl ArgState {
         }
     }
 }
+#[derive(Clone, Debug, PartialEq)]
+pub struct FontConfig {
+    pub font_file: String,
+}
+
 
 pub fn capitalize(s: &str) -> String {
     let mut c = s.chars();

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,12 +1,18 @@
+use eframe::egui;
 use eframe::egui::{
     Button, CentralPanel, Checkbox, CollapsingHeader, Context, Grid, RichText, ScrollArea,
     TextEdit, Ui, Visuals,
 };
 
+
 use crate::Claui;
 
 impl eframe::App for Claui {
     fn update(&mut self, ctx: &Context, _frame: &mut eframe::Frame) {
+        if self.font_config.is_some() && !self.font_loaded {
+            self.load_font(ctx);
+            self.font_loaded = true;
+        }
         self.update_buffer();
         self.update_thread_state();
 
@@ -145,5 +151,23 @@ impl Claui {
                         .cursor_at_end(true),
                 )
             });
+    }
+    pub fn load_font(&self, ctx: &Context) {
+        if let Some(font_config) = self.font_config.clone() {
+            let ref font_path = font_config.font_file;
+            if let Ok(font_data) = std::fs::read(font_path) {
+                let mut fonts = egui::FontDefinitions::default();
+                fonts.font_data.insert(
+                    "custom_font".to_owned(),
+                    egui::FontData::from_owned(font_data),
+                );
+                fonts.families.get_mut(&egui::FontFamily::Proportional).unwrap().insert(0, "custom_font".to_owned());
+                fonts.families.get_mut(&egui::FontFamily::Monospace).unwrap().insert(0, "custom_font".to_owned());
+                ctx.set_fonts(fonts);
+            } else {
+                eprintln!("Failed to load font file: {}", font_path);
+            }
+        }
+
     }
 }


### PR DESCRIPTION
## Description
This PR introduces the ability for users to utilize custom TrueType Fonts (TTF) within the library. The primary motivation behind this change is to enable the support for different languages and custom font styles, which is essential for applications aiming for a broader audience, particularly for those requiring support for Chinese characters.

## Changes
- Expose `FontConfig` from the `misc` module to the public API.
- Add documentation and examples demonstrating how to use a local `.ttf` file.

## Benefits
- Users can now specify their own `.ttf` files, allowing for greater customization of font styles and language support.

## Example Usage
```rust
use claui::FontConfig;

// Assuming `your_library` is the name of the crate you're contributing to
fn main() {
    let app = Args::command();
    let font_config = FontConfig {
        font_file: "./方正黑体简体.ttf".to_string(),
    };
    claui::run(app, |matches| {
        println!("Hello, {}!", matches.get_one::<String>("name").unwrap());
        if matches.get_flag("goodbye") {
            println!("Goodbye!");
        }
    },Some(font_config));}